### PR TITLE
Versioning to use setuptools_scm

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         conda create -n test_vtools3 -y conda-build conda-verify numpy anaconda-client setuptools-scm
         source $CONDA/etc/profile.d/conda.sh
+        GIT_DESCRIBE_TAG=$(git describe --tags --abbrev=0)
         conda activate test_vtools3
         conda config --set anaconda_upload yes
         conda build -c cadwr-dms -c conda-forge --user cadwr-dms --token "$ANACONDA_CHANNEL_UPLOAD_TOKEN" conda.recipe

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -26,9 +26,9 @@ jobs:
       run: |
         conda create -n test_vtools3 -y conda-build conda-verify numpy anaconda-client setuptools-scm
         source $CONDA/etc/profile.d/conda.sh
-        GIT_DESCRIBE_TAG=$(git describe --tags --abbrev=0)
         conda activate test_vtools3
         conda config --set anaconda_upload yes
+        export SETUPTOOLS_SCM_PRETEND_VERSION=$(python -m setuptools_scm)
         conda build -c cadwr-dms -c conda-forge --user cadwr-dms --token "$ANACONDA_CHANNEL_UPLOAD_TOKEN" conda.recipe
         conda activate
         conda remove -n test_vtools3 --all

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,11 +1,11 @@
 {# raw is for ignoring templating with cookiecutter, leaving it for use with conda-build -#}
 {% set pyproject = load_file_data('../pyproject.toml', from_recipe_dir=True) %}
 {% set project = pyproject['project'] %}
-{% set version = load_setup_py_data().get('version', '0.0.0') %}
+#{% set version = load_setup_py_data().get('version', '0.0.0') %}
 
 package:
   name: vtools3
-  version: {{ version }}
+  version: {{ GIT_DESCRIBE_TAG }}
 
 source:
   path: ..
@@ -15,6 +15,8 @@ build:
   # separate bld.bat and build.sh files instead of this key.  Add the line
   # "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or
   # "skip: True  # [not win]" to limit to Windows.
+  script_env:
+   - SETUPTOOLS_SCM_PRETEND_VERSION={{ GIT_DESCRIBE_TAG }}
   script: {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -vv .
   noarch: python
   number: 0

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,7 +5,7 @@
 
 package:
   name: vtools3
-  version: {{ GIT_DESCRIBE_TAG }}
+  version: {{ SETUPTOOLS_SCM_PRETEND_VERSION }}
 
 source:
   path: ..
@@ -16,7 +16,7 @@ build:
   # "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or
   # "skip: True  # [not win]" to limit to Windows.
   script_env:
-   - SETUPTOOLS_SCM_PRETEND_VERSION={{ GIT_DESCRIBE_TAG }}
+   - SETUPTOOLS_SCM_PRETEND_VERSION
   script: {{ PYTHON }} -m pip install --no-build-isolation --no-deps --ignore-installed -vv .
   noarch: python
   number: 0


### PR DESCRIPTION
@lily-tomkovic-DWR versioning relies on an envvar being set. This is now included in the github action workflow. For local you will have to set it in your environment when testing conda build. pip install will not need it as it uses pyproject.toml to configure the version with setuptools_scm